### PR TITLE
Add --uppercase flag to --greet

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ Options:
   --help, -h     Show this help message
   --version, -v  Show version
   --greet NAME   Greet someone
+  --uppercase    Print greeting in uppercase (use with --greet)
   --timer SEC    Start a countdown timer`);
   process.exit(0);
 }
@@ -23,7 +24,8 @@ if (args.includes("--version") || args.includes("-v")) {
 const parsed = parseArgs(args);
 
 if (parsed.greet) {
-  console.log(`Hello, ${parsed.greet}!`);
+  const greeting = `Hello, ${parsed.greet}!`;
+  console.log(args.includes("--uppercase") ? greeting.toUpperCase() : greeting);
 } else if (parsed.timer) {
   const seconds = parseInt(parsed.timer, 10);
   if (isNaN(seconds) || seconds <= 0) {


### PR DESCRIPTION
## Summary
- Adds `--uppercase` flag that works with `--greet NAME` to print greeting in all caps
- Example: `tasks-fixture --greet Alice --uppercase` → `HELLO, ALICE!`
- Updates help text to document the new flag

## Test plan
- [x] Verified `--greet Alice` still outputs `Hello, Alice!`
- [x] Verified `--greet Alice --uppercase` outputs `HELLO, ALICE!`
- [x] Verified `--help` shows the new `--uppercase` option

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)